### PR TITLE
Fix provider name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-# localfile_provider
+# localfile provider
 
 ## Generating Terraform documentation
 
 This project uses `tfplugindocs` to generate Terraform documentation.
-Install the tool and run it from the repository root:
+Install the tool and run it from the repository root.
+Because the repository directory contains an underscore, `tfplugindocs`
+cannot automatically determine the provider name. Run the helper script to
+invoke the command with the correct name:
 
 ```bash
 go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
 
 # Generate docs in the ./docs directory
-tfplugindocs
+scripts/generate-docs.sh
 ```
 

--- a/internal/data_source_txt.go
+++ b/internal/data_source_txt.go
@@ -79,7 +79,7 @@ func (d *txtDataSource) Configure(_ context.Context, req datasource.ConfigureReq
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Provider Data Type",
-			"The provider data for local-file_txt data source must be a *FileClient.",
+			"The provider data for localfile_txt data source must be a *FileClient.",
 		)
 		return
 	}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -14,6 +14,9 @@ import (
 	"path/filepath"
 )
 
+// ProviderTypeName is the Terraform provider type name.
+const ProviderTypeName = "localfile"
+
 // Compile-time assertion to ensure provider implementation satisfies
 // required interfaces.
 var _ provider.Provider = &localfileProvider{}
@@ -40,7 +43,7 @@ type providerModel struct {
 
 // Metadata sets the provider type name and version.
 func (p *localfileProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "local-file"
+	resp.TypeName = ProviderTypeName
 	resp.Version = p.version
 }
 
@@ -56,8 +59,8 @@ func (p *localfileProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 				Description: "Base directory for all file operations. Must be an existing directory.",
 			},
 		},
-		Description:         "The local-file provider manages simple text files and zip archives within a designated base directory.",
-		MarkdownDescription: "The local-file provider manages simple text files and zip archives within a designated base directory.",
+		Description:         "The localfile provider manages simple text files and zip archives within a designated base directory.",
+		MarkdownDescription: "The localfile provider manages simple text files and zip archives within a designated base directory.",
 	}
 }
 
@@ -89,7 +92,7 @@ func (p *localfileProvider) Configure(ctx context.Context, req provider.Configur
 		resp.Diagnostics.AddAttributeError(
 			path.Root("base_dir"),
 			"Missing base_dir",
-			"The base_dir must be specified for the local-file provider.",
+			"The base_dir must be specified for the localfile provider.",
 		)
 		return
 	}
@@ -127,13 +130,13 @@ func (p *localfileProvider) Configure(ctx context.Context, req provider.Configur
 	// on the HashiCorp logging tutorial, which recommends using
 	// tflog.SetField and tflog.Debug/Info around client creation【844297507211234†L343-L365】.
 	ctx = tflog.SetField(ctx, "local_file_base_dir", absDir)
-	tflog.Debug(ctx, "Configuring local-file provider")
+	tflog.Debug(ctx, "Configuring localfile provider")
 	// Initialize client
 	client := &FileClient{BaseDir: absDir}
 	// Expose client to resources and data sources
 	resp.DataSourceData = client
 	resp.ResourceData = client
-	tflog.Info(ctx, "Configured local-file provider", map[string]any{"success": true})
+	tflog.Info(ctx, "Configured localfile provider", map[string]any{"success": true})
 }
 
 // Resources returns the list of resource implementations supported by

--- a/internal/provider_acc_test.go
+++ b/internal/provider_acc_test.go
@@ -10,20 +10,20 @@ import (
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"local-file": providerserver.NewProtocol6WithError(NewProvider("test")),
+	ProviderTypeName: providerserver.NewProtocol6WithError(NewProvider("test")),
 }
 
 func testAccTxtResourceConfig(baseDir, data string) string {
 	return fmt.Sprintf(`
-provider "local-file" {
+provider "%s" {
   base_dir = "%s"
 }
 
-resource "local-file_txt" "test" {
+resource "%s_txt" "test" {
   name = "acc.txt"
   data = "%s"
 }
-`, baseDir, data)
+`, ProviderTypeName, baseDir, ProviderTypeName, data)
 }
 
 func TestAccTxtResource_basic(t *testing.T) {
@@ -37,13 +37,13 @@ func TestAccTxtResource_basic(t *testing.T) {
 			{
 				Config: testAccTxtResourceConfig(tempDir, "hello"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("local-file_txt.test", "data", "hello"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("%s_txt.test", ProviderTypeName), "data", "hello"),
 				),
 			},
 			{
 				Config: testAccTxtResourceConfig(tempDir, "updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("local-file_txt.test", "data", "updated"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("%s_txt.test", ProviderTypeName), "data", "updated"),
 				),
 			},
 		},
@@ -52,19 +52,19 @@ func TestAccTxtResource_basic(t *testing.T) {
 
 func testAccTxtDataSourceConfig(baseDir string) string {
 	return fmt.Sprintf(`
-provider "local-file" {
+provider "%s" {
   base_dir = "%s"
 }
 
-resource "local-file_txt" "write" {
+resource "%s_txt" "write" {
   name = "data.txt"
   data = "from resource"
 }
 
-data "local-file_txt" "read" {
-  name = local-file_txt.write.name
+data "%s_txt" "read" {
+  name = %s_txt.write.name
 }
-`, baseDir)
+`, ProviderTypeName, baseDir, ProviderTypeName, ProviderTypeName, ProviderTypeName)
 }
 
 func TestAccTxtDataSource_basic(t *testing.T) {
@@ -78,8 +78,8 @@ func TestAccTxtDataSource_basic(t *testing.T) {
 			{
 				Config: testAccTxtDataSourceConfig(tempDir),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.local-file_txt.read", "data", "from resource"),
-					resource.TestCheckResourceAttr("local-file_txt.write", "data", "from resource"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("data.%s_txt.read", ProviderTypeName), "data", "from resource"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("%s_txt.write", ProviderTypeName), "data", "from resource"),
 				),
 			},
 		},

--- a/internal/resource_txt.go
+++ b/internal/resource_txt.go
@@ -96,7 +96,7 @@ func (r *txtResource) Configure(_ context.Context, req resource.ConfigureRequest
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Provider Data Type",
-			"The provider data for local-file_txt must be a *FileClient.",
+			"The provider data for localfile_txt must be a *FileClient.",
 		)
 		return
 	}

--- a/internal/resource_zip.go
+++ b/internal/resource_zip.go
@@ -48,7 +48,7 @@ func (r *zipResource) Metadata(_ context.Context, req resource.MetadataRequest, 
 }
 
 // Schema defines the attributes for the zip resource.  The
-// src_data_file attribute should reference the ID of a local-file-txt
+// src_data_file attribute should reference the ID of a localfile-txt
 // resource (the absolute path to the file).  Name and location
 // determine where the zip file is written.  Changes to these
 // attributes require recreation.
@@ -63,8 +63,8 @@ func (r *zipResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 			"src_data_file": schema.StringAttribute{
 				Required:            true,
-				Description:         "Absolute path to the source file to include in the zip. Typically references a local-file-txt resource's id.",
-				MarkdownDescription: "Absolute path to the source file to include in the zip. Typically references a local-file-txt resource's id.",
+				Description:         "Absolute path to the source file to include in the zip. Typically references a localfile-txt resource's id.",
+				MarkdownDescription: "Absolute path to the source file to include in the zip. Typically references a localfile-txt resource's id.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{
@@ -95,7 +95,7 @@ func (r *zipResource) Configure(_ context.Context, req resource.ConfigureRequest
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Provider Data Type",
-			"The provider data for local-file_onefile_zip must be a *FileClient.",
+			"The provider data for localfile_onefile_zip must be a *FileClient.",
 		)
 		return
 	}

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate Terraform provider documentation.
+# Uses explicit provider name to avoid errors from underscores in the
+# repository name.
+
+tfplugindocs --provider-name=localfile "$@"


### PR DESCRIPTION
## Summary
- rename provider to `localfile`
- update docs and helper script
- adjust error messages in data source and resources

## Testing
- `go test ./...`
- `./scripts/generate-docs.sh` *(fails: tfplugindocs not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae74e29d883299a6fbd928e4fb67d